### PR TITLE
handle case when upload endpoint returns zero

### DIFF
--- a/chronicle/Models/Operations.swift
+++ b/chronicle/Models/Operations.swift
@@ -128,7 +128,7 @@ class UploadDataOperation: Operation {
                     self.uploading = true
                     UserDefaults.standard.set(true, forKey: UserSettingsKeys.isUploading)
 
-                    ApiClient.uploadData(sensorData: data, enrollment: enrollment, deviceId: deviceId) {
+                    ApiClient.uploadData(sensorData: data, count: objects.count, enrollment: enrollment, deviceId: deviceId) {
                         self.logger.info("successfully uploaded \(objects.count) to server")
                         objects.forEach (self.context.delete) // delete uploaded data from local db
                         try? self.context.save()

--- a/chronicle/Utilities/ApiClient.swift
+++ b/chronicle/Utilities/ApiClient.swift
@@ -64,7 +64,7 @@ struct ApiClient {
     }
     
     // upload SensorData to server
-    static func uploadData(sensorData: Data, enrollment: Enrollment, deviceId: String, onCompletion: @escaping() -> Void, onError: @escaping (String) -> Void) {
+    static func uploadData(sensorData: Data, count: Int, enrollment: Enrollment, deviceId: String, onCompletion: @escaping() -> Void, onError: @escaping (String) -> Void) {
         
         let urlComponents: URLComponents? = ApiUtils.createSensorDataUploadURLComponents(enrollment: enrollment, deviceId: deviceId)
         
@@ -95,6 +95,15 @@ struct ApiClient {
                 return
             }
             
+            guard let data = data, let written = try? JSONDecoder().decode(Int.self, from: data) else {
+                onError("unable to decode response")
+                return
+            }
+            
+            if (written != count) {
+                onError("expected to persist \(count) objects on server but persisted \(written)")
+                return
+            }
             onCompletion()
         }
         


### PR DESCRIPTION
- When no data is persisted on server (for example, when participant is marked as not_enrolled) , client should not delete locally stored data
