### PR TITLE
Do no allow iPads to reach sensor authorization step.

### DIFF
--- a/chronicle/ViewModels/EnrollmentViewModel.swift
+++ b/chronicle/ViewModels/EnrollmentViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Generic state manager for views. Handles intents and sets up binding for various properties
 class EnrollmentViewModel: ObservableObject {
@@ -72,7 +73,12 @@ class EnrollmentViewModel: ObservableObject {
         let enrollment = Enrollment(participantId: participantId, studyId: studyId)
         validateInput(enrollment: enrollment)
         
-        guard enrollment.isValid else {
+        guard !DeviceSpecificErrors.IS_IPAD else {
+            self.showEnrollmentError = true
+            return
+        }
+        
+        guard enrollment.isValid  else {
             return
         }
         

--- a/chronicle/Views/EnrollmentView.swift
+++ b/chronicle/Views/EnrollmentView.swift
@@ -7,6 +7,17 @@
 
 import SwiftUI
 
+struct DeviceSpecificErrors {
+    static let IS_IPAD = UIDevice.current.userInterfaceIdiom == .pad
+    static let iPadFailureMesssage = """
+    iPad devices do not support SensorKit and cannot be enrolled in a study.
+    """
+    static let iOSFailureMessage = """
+    Failed to enroll device. Please double check that the Study ID and the Participant ID are correct. If the problem persists, please contact your study administrator.
+    """
+    static let failureMessage = DeviceSpecificErrors.IS_IPAD ? iPadFailureMesssage : iOSFailureMessage
+}
+
 struct EnrollmentView: View {
     
     @EnvironmentObject var viewModel: EnrollmentViewModel
@@ -15,7 +26,7 @@ struct EnrollmentView: View {
         Theme.navigationBarStyle()
     }
     
-    var body: some View {
+        var body: some View {
         NavigationView {
             Form {
                 Section(header: Text("Device Enrollment")) {
@@ -68,7 +79,7 @@ struct EnrollmentView: View {
             .alert(isPresented: $viewModel.showEnrollmentError) {
                 Alert(
                     title: Text("Device Enrollment Failed"),
-                    message: Text("Failed to enroll device. Please double check that the Study ID and the Participant ID are correct. If the problem persists, please contact your study administrator."),
+                    message: Text(DeviceSpecificErrors.failureMessage),
                     dismissButton: .default(Text("OK")))
             }
             .navigationTitle("Chronicle")


### PR DESCRIPTION
Apple app store is rejecting app because app crashes when trying to load missing SensorKit libraries. This changes prevents those libraries from being loaded by not allowing enrollment of iPad devices.